### PR TITLE
Add PDF name existence check example

### DIFF
--- a/PdfNameCheck.cs
+++ b/PdfNameCheck.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+class PdfNameCheck
+{
+    static void Main(string[] args)
+    {
+        Console.Write("Bitte geben Sie den gewünschten Dateinamen (mit .pdf) ein: ");
+        string fileName = Console.ReadLine();
+
+        while (File.Exists(fileName))
+        {
+            Console.WriteLine($"Die Datei '{fileName}' existiert bereits.");
+            Console.Write("Möchten Sie einen anderen Namen eingeben? (j/n): ");
+            string reply = Console.ReadLine();
+            if (!reply.Equals("j", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("Vorgang abgebrochen.");
+                return;
+            }
+            Console.Write("Neuer Dateiname: ");
+            fileName = Console.ReadLine();
+        }
+
+        Console.WriteLine($"PDF wird unter '{fileName}' gespeichert.");
+        // TODO: Speichervorgang des PDFs implementieren
+    }
+}

--- a/README.md
+++ b/README.md
@@ -347,6 +347,32 @@ root.AppendChild(embedded);
 doc.Save("Rechnung_INV-2025-001.xml");
 ```
 
+### 10.4. PDF-Datei speichern mit Namensprüfung
+```csharp
+using System;
+using System.IO;
+
+Console.Write("Bitte geben Sie den gewünschten Dateinamen (mit .pdf) ein: ");
+string fileName = Console.ReadLine();
+
+while (File.Exists(fileName))
+{
+    Console.WriteLine($"Die Datei '{fileName}' existiert bereits.");
+    Console.Write("Möchten Sie einen anderen Namen eingeben? (j/n): ");
+    string reply = Console.ReadLine();
+    if (!reply.Equals("j", StringComparison.OrdinalIgnoreCase))
+    {
+        Console.WriteLine("Vorgang abgebrochen.");
+        return;
+    }
+    Console.Write("Neuer Dateiname: ");
+    fileName = Console.ReadLine();
+}
+
+Console.WriteLine($"PDF wird unter '{fileName}' gespeichert.");
+// Hier erfolgt der eigentliche Speichervorgang des PDFs
+```
+
 ---
 
 ## 11. Lizenz & Autor


### PR DESCRIPTION
## Summary
- add a small C# snippet for checking whether a PDF name already exists in **PdfNameCheck.cs**
- document the feature in README with a new example section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531b1fdba88330904b9f2d04f30cde